### PR TITLE
enable dynamic column write with bytes

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/hbase/HBaseRelation.scala
@@ -238,7 +238,7 @@ case class HBaseRelation(
       def addColumnWithTime(col: String)(ts: Long, value: Any) = if(value != null) {
         put.addColumn(coder.toBytes(field.cf), coder.toBytes(col), ts, dataType.toBytes(value))
       }
-      def addColumn(col: String, value: Any) = if(value != null) {
+      def addColumn(col: Any, value: Any) = if(value != null) {
         put.addColumn(coder.toBytes(field.cf), coder.toBytes(col), dataType.toBytes(value))
       }
       field.dt match {
@@ -255,6 +255,9 @@ case class HBaseRelation(
                   row(index).asInstanceOf[Map[String, Any]]
                     .foreach((addColumn _).tupled)
               }
+            case BinaryType =>
+              row(index).asInstanceOf[Map[Array[Byte], Any]]
+                .foreach((addColumn _).tupled)
             case LongType =>
               row(index).asInstanceOf[Map[Long, Any]]
                 .foreach((addColumnWithTime(field.col) _).tupled)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Current dynamic column write can only work with string, change to work with bytes

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
